### PR TITLE
Fixed the width of the social proof block

### DIFF
--- a/assets/scss/components/_social-proof.scss
+++ b/assets/scss/components/_social-proof.scss
@@ -7,8 +7,7 @@
   }
 
   @include breakpoint(from-large) {
-    justify-content: space-between;
-    grid-auto-flow: column;
+    grid-template-columns: repeat(4, 25%);
   }
 
   &__link {


### PR DESCRIPTION
# Description

Fixed the bug on social proof block. Made their width to be equal to prevent the text from overflowing.

Fixes # (issue) https://app.asana.com/0/1125451579593811/1201071542242223

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code

![image](https://user-images.githubusercontent.com/60210400/154897194-b6be500c-f5fd-4534-a508-37c623231a9a.png)
