### PR TITLE
Left right align illustration for big case study

### DIFF
--- a/assets/scss/utilities/__import.scss
+++ b/assets/scss/utilities/__import.scss
@@ -6,6 +6,7 @@
 'utilities/display',
 'utilities/empty',
 'utilities/flex',
+'utilities/mirrored',
 'utilities/gc',
 'utilities/gc-start',
 'utilities/height',

--- a/assets/scss/utilities/_mirrored.scss
+++ b/assets/scss/utilities/_mirrored.scss
@@ -1,0 +1,5 @@
+@include make-utility((
+    alias: 'mirrored',
+    class: true,
+    transform: scaleX(-1)
+));

--- a/src/metaboxes/work_options.php
+++ b/src/metaboxes/work_options.php
@@ -22,6 +22,12 @@ return [
             'desc' => 'Background image that sits inside the gray background section in Case Study Link Blocks.'
         ],
         [
+            'name' => 'Illustration Background Mirrored',
+            'id'   => 'image_background_mirrored',
+            'type' => 'file',
+            'desc' => 'Background image that sits inside the gray background section in Case Study Link Blocks.'
+        ],
+        [
             'name' => 'Illustration (Large)',
             'id'   => 'image_large',
             'type' => 'file',

--- a/src/template_parts/block_case_study.php
+++ b/src/template_parts/block_case_study.php
@@ -23,9 +23,14 @@
   $title = getPostMeta('work_single_work_options_link_block_title', $caseStudyId);
   $linkText = 'Find out more';
   $linkURL = get_the_permalink($caseStudyId);
-  $imgBackgroundId = getPostMeta('work_single_work_options_image_background_id', $caseStudyId);
+  $imgBackgroundStandardId = getPostMeta('work_single_work_options_image_background_id', $caseStudyId);
   $imgBackgroundMirroredId = getPostMeta('work_single_work_options_image_background_mirrored_id', $caseStudyId);
-  $checkIfMirroredImgBackgroundIsExist = ($imgBackgroundMirroredId && $caseStudyIndex % 2 === 0) ? $imgBackgroundMirroredId : $imgBackgroundId;
+
+  if ($caseStudyIndex % 2 === 0) {
+    $imgBackgroundId = $imgBackgroundMirroredId ? $imgBackgroundMirroredId : $imgBackgroundStandardId;
+  } else {
+    $imgBackgroundId = $imgBackgroundStandardId;
+  }
 
   $imgLargeId = getPostMeta('work_single_work_options_image_large_id', $caseStudyId);
   $imgMediumId = getPostMeta('work_single_work_options_image_medium_id', $caseStudyId);
@@ -35,9 +40,9 @@
 <a href="<?= $linkURL ?>"
    class="c-case-study-block c-case-study-block--<?= $caseStudySize ?><?= $staggeredClass ?> js-half-onscreen-detect">
   <div class="c-case-study-block__background">
-    <?php if ($caseStudySize === 'large' && ($checkIfMirroredImgBackgroundIsExist || $imgBackgroundMirroredId)) : ?>
+    <?php if ($caseStudySize === 'large' && $imgBackgroundId) : ?>
       <div class="c-case-study-block__image-background <?= (!$imgBackgroundMirroredId && $caseStudyIndex % 2 === 0) ? 'u-mirrored' : '' ?>">
-        <?= lazyLoad(wp_get_attachment_image($checkIfMirroredImgBackgroundIsExist, 'link-block-case-study-bg-large')) ?>
+        <?= lazyLoad(wp_get_attachment_image($imgBackgroundId, 'link-block-case-study-bg-large')) ?>
       </div>
     <?php endif; ?>
     <?php if ($caseStudySize === 'large' && $imgLargeId) : ?>

--- a/src/template_parts/block_case_study.php
+++ b/src/template_parts/block_case_study.php
@@ -25,7 +25,7 @@
   $linkURL = get_the_permalink($caseStudyId);
   $imgBackgroundId = getPostMeta('work_single_work_options_image_background_id', $caseStudyId);
   $imgBackgroundMirroredId = getPostMeta('work_single_work_options_image_background_mirrored_id', $caseStudyId);
-  $checkIfMirroredImgBackgroundIsExist = ($imgBackgroundMirroredId && ($caseStudyIndex % 2 === 0)) ? $imgBackgroundMirroredId : $imgBackgroundId;
+  $checkIfMirroredImgBackgroundIsExist = ($imgBackgroundMirroredId && $caseStudyIndex % 2 === 0) ? $imgBackgroundMirroredId : $imgBackgroundId;
 
   $imgLargeId = getPostMeta('work_single_work_options_image_large_id', $caseStudyId);
   $imgMediumId = getPostMeta('work_single_work_options_image_medium_id', $caseStudyId);
@@ -35,8 +35,8 @@
 <a href="<?= $linkURL ?>"
    class="c-case-study-block c-case-study-block--<?= $caseStudySize ?><?= $staggeredClass ?> js-half-onscreen-detect">
   <div class="c-case-study-block__background">
-    <?php if ($caseStudySize === 'large' && $imgBackgroundId) : ?>
-      <div class="c-case-study-block__image-background <?= $caseStudyIndex % 2 === 0 ? 'u-mirrored' : '' ?>">
+    <?php if ($caseStudySize === 'large' && ($checkIfMirroredImgBackgroundIsExist || $imgBackgroundMirroredId)) : ?>
+      <div class="c-case-study-block__image-background <?= (!$imgBackgroundMirroredId && $caseStudyIndex % 2 === 0) ? 'u-mirrored' : '' ?>">
         <?= lazyLoad(wp_get_attachment_image($checkIfMirroredImgBackgroundIsExist, 'link-block-case-study-bg-large')) ?>
       </div>
     <?php endif; ?>

--- a/src/template_parts/block_case_study.php
+++ b/src/template_parts/block_case_study.php
@@ -58,8 +58,10 @@
   </div>
   <div class="c-case-study-block__content">
     <?php if ($logoSrc) : ?>
-      <div class="c-case-study-block__logo"
-           style="<?= $logoMask ?>">
+      <div
+        class="c-case-study-block__logo"
+        style="<?= $logoMask ?>"
+      >
         <?php if ($logoAlt) : ?>
           <span class="c-case-study-block__logo__alt">
             <?= $logoAlt ?>

--- a/src/template_parts/block_case_study.php
+++ b/src/template_parts/block_case_study.php
@@ -24,9 +24,15 @@
   $linkText = 'Find out more';
   $linkURL = get_the_permalink($caseStudyId);
   $imgBackgroundId = getPostMeta('work_single_work_options_image_background_id', $caseStudyId);
+  $imgBackgroundMirroredId = getPostMeta('work_single_work_options_image_background_mirrored_id', $caseStudyId);
+  // if ($imgBackgroundMirroredId && ($caseStudyIndex % 2 !== 0)) {
+  //   $imgBackgroundId = $imgBackgroundMirroredId;
+  // }
+
   $imgLargeId = getPostMeta('work_single_work_options_image_large_id', $caseStudyId);
   $imgMediumId = getPostMeta('work_single_work_options_image_medium_id', $caseStudyId);
   $imgSmallId = getPostMeta('work_single_work_options_image_small_id', $caseStudyId);
+  var_dump($caseStudyIndex);
 ?>
 
 <a href="<?= $linkURL ?>"
@@ -34,7 +40,7 @@
   <div class="c-case-study-block__background">
     <?php if ($caseStudySize === 'large' && $imgBackgroundId) : ?>
       <div class="c-case-study-block__image-background">
-        <?= lazyLoad(wp_get_attachment_image($imgBackgroundId, 'link-block-case-study-bg-large')) ?>
+        <?= lazyLoad(wp_get_attachment_image(($imgBackgroundMirroredId && ($caseStudyIndex % 2 !== 0)) ? $imgBackgroundMirroredId : $imgBackgroundId, 'link-block-case-study-bg-large')) ?>
       </div>
     <?php endif; ?>
     <?php if ($caseStudySize === 'large' && $imgLargeId) : ?>

--- a/src/template_parts/block_case_study.php
+++ b/src/template_parts/block_case_study.php
@@ -25,22 +25,19 @@
   $linkURL = get_the_permalink($caseStudyId);
   $imgBackgroundId = getPostMeta('work_single_work_options_image_background_id', $caseStudyId);
   $imgBackgroundMirroredId = getPostMeta('work_single_work_options_image_background_mirrored_id', $caseStudyId);
-  // if ($imgBackgroundMirroredId && ($caseStudyIndex % 2 !== 0)) {
-  //   $imgBackgroundId = $imgBackgroundMirroredId;
-  // }
+  $checkIfMirroredImgBackgroundIsExist = ($imgBackgroundMirroredId && ($caseStudyIndex % 2 === 0)) ? $imgBackgroundMirroredId : $imgBackgroundId;
 
   $imgLargeId = getPostMeta('work_single_work_options_image_large_id', $caseStudyId);
   $imgMediumId = getPostMeta('work_single_work_options_image_medium_id', $caseStudyId);
   $imgSmallId = getPostMeta('work_single_work_options_image_small_id', $caseStudyId);
-  var_dump($caseStudyIndex);
 ?>
 
 <a href="<?= $linkURL ?>"
    class="c-case-study-block c-case-study-block--<?= $caseStudySize ?><?= $staggeredClass ?> js-half-onscreen-detect">
   <div class="c-case-study-block__background">
     <?php if ($caseStudySize === 'large' && $imgBackgroundId) : ?>
-      <div class="c-case-study-block__image-background">
-        <?= lazyLoad(wp_get_attachment_image(($imgBackgroundMirroredId && ($caseStudyIndex % 2 !== 0)) ? $imgBackgroundMirroredId : $imgBackgroundId, 'link-block-case-study-bg-large')) ?>
+      <div class="c-case-study-block__image-background <?= $caseStudyIndex % 2 === 0 ? 'u-mirrored' : '' ?>">
+        <?= lazyLoad(wp_get_attachment_image($checkIfMirroredImgBackgroundIsExist, 'link-block-case-study-bg-large')) ?>
       </div>
     <?php endif; ?>
     <?php if ($caseStudySize === 'large' && $imgLargeId) : ?>

--- a/src/template_parts/block_section_case_study_large.php
+++ b/src/template_parts/block_section_case_study_large.php
@@ -1,5 +1,6 @@
 <?php
   $caseStudySize = 'large';
+  $caseStudyIndex = 1;
 ?>
 
 <?php if (isset($globalCaseStudyIds) && !empty($globalCaseStudyIds)) : ?>
@@ -9,8 +10,9 @@
       <?php foreach ($globalCaseStudyIds as $caseStudyId) : ?>
         <?php include(locate_template('src/template_parts/block_case_study.php')) ?>
         <?php if (is_page_template(('template-all-case-studies.php'))) : ?>
-        <?php include(locate_template('src/template_parts/block_case_study.php')) ?>
+          <?php include(locate_template('src/template_parts/block_case_study.php')) ?>
         <?php endif; ?>
+        <?php $caseStudyIndex++; ?>
       <?php endforeach; ?>
 
       <?php if (is_front_page()) : ?>

--- a/src/template_parts/block_section_case_study_large.php
+++ b/src/template_parts/block_section_case_study_large.php
@@ -9,29 +9,37 @@
     <div class="o-container-case-studies o-container-case-studies--flex">
       <?php foreach ($globalCaseStudyIds as $caseStudyId) : ?>
         <?php include(locate_template('src/template_parts/block_case_study.php')) ?>
+
         <?php if (is_page_template(('template-all-case-studies.php'))) : ?>
           <?php include(locate_template('src/template_parts/block_case_study.php')) ?>
         <?php endif; ?>
+
         <?php $caseStudyIndex++; ?>
       <?php endforeach; ?>
 
       <?php if (is_front_page()) : ?>
         <div class="o-container-content">
-          <a href="/our-work"
-             class="c-case-study-block c-case-study-block--large c-case-study-block--more js-half-onscreen-detect"
-             aria-labelledby="see-more-text"
+          <a
+            href="/our-work"
+            class="c-case-study-block c-case-study-block--large c-case-study-block--more js-half-onscreen-detect"
+            aria-labelledby="see-more-text"
           >
-             <div class="c-case-study-block__content c-case-study-block--more__content">
-                <img src="<?= get_template_directory_uri() ?>/dist/svg/bubble.svg" alt="Bubble with ellipsis" width="58px" height="54px"/>
+            <div class="c-case-study-block__content c-case-study-block--more__content">
+              <img
+                src="<?= get_template_directory_uri() ?>/dist/svg/bubble.svg"
+                alt="Bubble with ellipsis"
+                width="58px"
+                height="54px"
+              />
 
-                <div
-                  id="see-more-text"
-                  class="c-case-study-block__link c-button c-button--underlined-dark c-button--short-underline"
-                >
-                  See more of our work
-                </div>
-             </div>
-         </a>
+              <div
+                id="see-more-text"
+                class="c-case-study-block__link c-button c-button--underlined-dark c-button--short-underline"
+              >
+                See more of our work
+              </div>
+            </div>
+          </a>
         </div>
      <?php endif; ?>
     </div>


### PR DESCRIPTION
# Description

Mirrored the image background on big case study and added a new field for the image that has text in it. 

Fixes # (task) https://app.asana.com/0/1125451579593811/1201431758723303/f

## Type of change

- [X] New feature

## Front-end Dev Checklist

#### General
- [x] I've included the [Front-end Dev Checklist](https://github.com/wearelighthouse/front-end-dev-checklist) in my PR.
- [X] Filenames correctly match a single template, component, function, etc. inside each file.
- [ ] 'Magic numbers' (including color codes) are assigned to suitable variable names, or have explanatory comments.
- [X] TODOs have been documented elsewhere or have been removed.
- [X] `console.log()`s. `var_dump`s or other temporary debugging techniques have been removed.
- [X] No build task or browser warnings/errors have been introduced.
- [X] Unused code has been removed rather than commented-out.

#### CSS
- [X] BEM class names match up with HTML structure.
- [X] Class names have the correct namespace prefixes (c-, o-, s-, t-, u-).
- [X] Utility classes e.g. `u-ml-4` and `u-color-red` have been used instead of hardcoded values.
- [ ] [Pseudo-classes](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes) & [attribute selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors) have been used over class-based selectors where possible.
- [ ] [Type selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/Type_selectors) have only been used within reset, scope, or third-party classes.
- [ ] Interactive elements have `:hover`, `:focus` and `:focus-visible` states.

#### Browser & device support
- [X] Tested across multiple screen sizes.
- [X] Tested across multiple browsers.
- [ ] Tested across multiple devices.
- [X] Checked [caniuse.com](https://caniuse.com/) for support of particular features.
