### PR TITLE
Smaller gap between images

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -73,23 +73,12 @@ function swapEmailFromHelloToHi() {
   });
 }
 
-function removeSpaceCharacter() {
-  let emptydivs = document.querySelectorAll('.u-hide-if-empty');
-
-  for (let i = 0; i < emptydivs.length; i++) {
-    if(emptydivs[i].innerHTML.replace(/^\s*/, "").replace(/\s*$/, "") == "") {
-      emptydivs[i].style.display = 'none';
-    }
-  }
-}
-
 function completeInit() {
   // Do lazy loading images
   setupObservers(window.lozad);
   // Add document.referrer into cache
   addReferral(document.referrer);
   swapEmailFromHelloToHi();
-  removeSpaceCharacter();
 }
 
 window.addEventListener('beforeunload', function (e) {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -73,12 +73,23 @@ function swapEmailFromHelloToHi() {
   });
 }
 
+function removeSpaceCharacter() {
+  let emptydivs = document.querySelectorAll('.u-hide-if-empty');
+
+  for (let i = 0; i < emptydivs.length; i++) {
+    if(emptydivs[i].innerHTML.replace(/^\s*/, "").replace(/\s*$/, "") == "") {
+      emptydivs[i].style.display = 'none';
+    }
+  }
+}
+
 function completeInit() {
   // Do lazy loading images
   setupObservers(window.lozad);
   // Add document.referrer into cache
   addReferral(document.referrer);
   swapEmailFromHelloToHi();
+  removeSpaceCharacter();
 }
 
 window.addEventListener('beforeunload', function (e) {

--- a/functions.php
+++ b/functions.php
@@ -176,3 +176,15 @@ function enqueueResources()
   );
 }
 add_action('wp_enqueue_scripts', 'enqueueResources');
+
+function removeSpaceBetweenShortcodes($content) {
+  if ( is_singular() && in_the_loop() && is_main_query() ) {
+    $pattern = '/\[\/image\][\s]{4}\[image/';
+    $replace = '[/image][image';
+    return preg_replace($pattern, $replace, $content);
+  }
+
+  return $content;
+}
+
+add_filter( 'the_content',  'removeSpaceBetweenShortcodes', 1);

--- a/single-work.php
+++ b/single-work.php
@@ -44,7 +44,7 @@
   }
 
   $svgSpriteSheet = get_template_directory_uri() . '/dist/svg/sprites.svg';
-
+  
 ?>
 
 <?php get_header(); ?>


### PR DESCRIPTION
# Description

Remove a space character between the empty div which has the u-hide-if-empty class name and then remove the element which have a space character completely from the page with its margin.

Task: https://app.asana.com/0/1125451579593811/1202188903624116/f