### PR TITLE
Simplify YouTube embed CSS with aspect-ratio

### DIFF
--- a/assets/scss/components/_embed.scss
+++ b/assets/scss/components/_embed.scss
@@ -1,30 +1,20 @@
-
 .c-embed {
   margin-top: calc(var(--container-v-pad));
   margin-bottom: calc(var(--container-v-pad));
 }
 
+// E.g. YouTube embeds
 .c-embed--video {
-  @extend %u-width-100pc;
-  @extend %u-pos-relative;
   grid-column: 1 / -1;
 
-  // Hacks to get the video to scale with 100% width properly >.>
-  height: 0;
-  padding-bottom: 56.21%;
-  clip-path: inset(1px 1px);
-
   iframe {
-    @extend %u-width-100pc;
-    @extend %u-height-100pc;
-    @extend %u-pos-absolute;
-    @extend %u-top;
-    @extend %u-left;
+    width: 100%;
+    height: auto;
+    aspect-ratio: 500 / 281;
   }
 }
 
 .c-embed--generic {
-
   .twitter-tweet {
     @extend %u-mh-auto;
   }

--- a/functions.php
+++ b/functions.php
@@ -122,9 +122,9 @@ function addNavMenuItemIndexCssVar($atts, $item, $args)
 }
 add_filter('nav_menu_link_attributes', 'addNavMenuItemIndexCssVar', 10, 3);
 
-// Changing wrapping oembeds from <p> to <div> with a specific classname, and...
-// add "nocookie" To WordPress oEmbeded Youtube Videos
-// from: https://wordpress.org/support/topic/video-shortcode-youtube-nocookie-not-working/
+// Changing wrapping oembeds from <p> to <div> with a specific classname, and
+// add "nocookie" To WordPress oEmbeded Youtube Videos.
+// From https://wordpress.org/support/topic/video-shortcode-youtube-nocookie-not-working/
 function modifyEmbeds($html, $url) {
   if (strpos($url, "youtube.com") !== false) {
     $html = str_replace('youtube.com', 'youtube-nocookie.com', $html);
@@ -133,7 +133,7 @@ function modifyEmbeds($html, $url) {
     return '<div class="c-embed c-embed--generic">' . $html . '</div>';
   }
 }
-add_filter( 'embed_oembed_html', 'modifyEmbeds', 10, 2); // WordPress
+add_filter('embed_oembed_html', 'modifyEmbeds', 10, 2);
 
 // Add "pseduo archive pages" for services, team, and work post types.
 // Note that 'has_archive' => false when declaring the post types.


### PR DESCRIPTION
The embed on https://wearelighthouse.com/blog/tips-for-launching-your-product-in-a-new-market/ wasn't working as expected, because it was using YouTube embed code pasted into the Text tab, rather than letting WordPress automatically handle a copy-pasted YouTube URL into the Visual content editor.

But we've also simplified the old CSS that was handling the video player resizing, to use aspect-ratio instead of the old padding-bottom hack.